### PR TITLE
Hotfix/mailtime 289

### DIFF
--- a/src/components/MailchimpSignupForm.js
+++ b/src/components/MailchimpSignupForm.js
@@ -23,7 +23,7 @@ const CustomForm = ({ status, message, onValidated }) => {
   }, [router.query]);
 
   useEffect(() => {
-    if (/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(email)) {
+    if (/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,})+$/.test(email)) {
       setIsValid(true);
     } else {
       setIsValid(false);


### PR DESCRIPTION
Fix the issue that the domain extension cannot be longer than 3 characters when users input the email address.
Now at least 2 characters, no upper limit.